### PR TITLE
add [[maybe_unused]]

### DIFF
--- a/src/aal/algorithm.hpp
+++ b/src/aal/algorithm.hpp
@@ -15,14 +15,14 @@ find(P const pred, I f, I const l, Is... fs) {
 }
 
 template <typename I, typename... Is, typename P>
-[[nodiscard]] constexpr auto
+[[nodiscard]] [[maybe_unused]] constexpr auto
 found(P const pred, I f, I const l, Is... fs) {
     auto const t = find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
 
 template <typename I, typename... Is, typename O, typename Op>
-constexpr auto
+[[maybe_unused]] constexpr auto
 transform(Op const op, O o, I f, I const l, Is... fs) {
     while (f != l) {
         *o = op(*f, *fs...);


### PR DESCRIPTION
https://gcc.gnu.org/onlinedocs/gcc-3.2/gcc/Warning-Options.html
```
-Wunused-function
Warn whenever a static function is declared but not defined or a non\-inline static function is unused.
-Wunused
All all the above -Wunused options combined.
In order to get a warning about an unused function parameter, you must either specify -W -Wunused or separately specify -Wunused-parameter.
-Werror
Make all warnings into errors.
```
I found gcc erroring, with unused and error turned on, if I'm including a hpp and a function isn't being used.

`find` doesn't need `[[maybe_unused]]` because it's used by `found`.

https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4505?view=msvc-160
Though on msvc it ignores `[[maybe_unused]]`
So I had to suppress the warning.
`/wd4505 # suppress unreferenced local function has been removed.`