### PR TITLE
Use for loop, (void)

### DIFF
--- a/src/aal/algorithm.hpp
+++ b/src/aal/algorithm.hpp
@@ -9,7 +9,7 @@ template <typename I, typename... Is, typename P>
 [[nodiscard]] constexpr auto
 find(P const pred, I f, I const l, Is... fs)
 {
-    for (;f != l;(void)++f, ((void)++fs, ...)) {
+    for (;f != l;++f, ((void)++fs, ...)) {
         if (pred(std::as_const(*f), std::as_const(*fs)...)) break;
     }
     return std::tuple{f, fs...};
@@ -25,7 +25,7 @@ any_of(P const pred, I f, I const l, Is... fs) {
 template <typename I, typename... Is, typename O, typename Op>
 constexpr auto
 transform(Op const op, O o, I f, I const l, Is... fs) {
-    for (;f != l;(void)++o, (void)++f, ((void)++fs, ...)) {
+    for (;f != l;++o, (void)++f, ((void)++fs, ...)) {
         *o = op(std::as_const(*f), std::as_const(*fs)...);
     }
     return o;

--- a/src/aal/algorithm.hpp
+++ b/src/aal/algorithm.hpp
@@ -10,7 +10,7 @@ template <typename I, typename... Is, typename P>
 find(P const pred, I f, I const l, Is... fs)
 {
     for (;f != l;++f, ((void)++fs, ...)) {
-        if (pred(std::as_const(*f), std::as_const(*fs)...)) break;
+        if (pred(*f, *fs...)) break;
     }
     return std::tuple{f, fs...};
 }
@@ -26,7 +26,7 @@ template <typename I, typename... Is, typename O, typename Op>
 constexpr auto
 transform(Op const op, O o, I f, I const l, Is... fs) {
     for (;f != l;++o, (void)++f, ((void)++fs, ...)) {
-        *o = op(std::as_const(*f), std::as_const(*fs)...);
+        *o = op(*f, *fs...);
     }
     return o;
 }

--- a/src/aal/algorithm.hpp
+++ b/src/aal/algorithm.hpp
@@ -1,15 +1,16 @@
 #pragma once
 #include <tuple>
+#include <utility>
 
 namespace aal {
 namespace var {
 
 template <typename I, typename... Is, typename P>
 [[nodiscard]] constexpr auto
-find(P const pred, I f, I const l, Is... fs) {
-    while (f != l) {
-        if (pred(*f, *fs...)) break;
-        ++f, (++fs, ...);
+find(P const pred, I f, I const l, Is... fs)
+{
+    for (;f != l;(void)++f, ((void)++fs, ...)) {
+        if (pred(std::as_const(*f), std::as_const(*fs)...)) break;
     }
     return std::tuple{f, fs...};
 }
@@ -24,9 +25,8 @@ any_of(P const pred, I f, I const l, Is... fs) {
 template <typename I, typename... Is, typename O, typename Op>
 constexpr auto
 transform(Op const op, O o, I f, I const l, Is... fs) {
-    while (f != l) {
-        *o = op(*f, *fs...);
-        ++o, ++f, (++fs, ...);
+    for (;f != l;(void)++o, (void)++f, ((void)++fs, ...)) {
+        *o = op(std::as_const(*f), std::as_const(*fs)...);
     }
     return o;
 }

--- a/src/aal/algorithm.hpp
+++ b/src/aal/algorithm.hpp
@@ -17,8 +17,9 @@ find(P pred, I f, I const l, Is... fs)
 
 template <typename I, typename... Is, typename P>
 [[nodiscard]] constexpr auto
-any_of(P pred, I f, I const l, Is... fs) {
-    auto const t = find(pred, f, l, fs...);
+any_of(P&& pred, I&& f, I const l, Is&&... fs) {
+    auto const t = find(std::forward<P>(pred), std::forward<I>(f), l,
+                      std::forward<Is>(fs)...);
     return std::get<0>(t) != l;
 }
 

--- a/src/aal/algorithm.hpp
+++ b/src/aal/algorithm.hpp
@@ -7,7 +7,7 @@ namespace var {
 
 template <typename I, typename... Is, typename P>
 [[nodiscard]] constexpr auto
-find(P const pred, I f, I const l, Is... fs)
+find(P pred, I f, I const l, Is... fs)
 {
     for (;f != l;++f, ((void)++fs, ...)) {
         if (pred(*f, *fs...)) break;
@@ -17,14 +17,14 @@ find(P const pred, I f, I const l, Is... fs)
 
 template <typename I, typename... Is, typename P>
 [[nodiscard]] constexpr auto
-any_of(P const pred, I f, I const l, Is... fs) {
+any_of(P pred, I f, I const l, Is... fs) {
     auto const t = find(pred, f, l, fs...);
     return std::get<0>(t) != l;
 }
 
 template <typename I, typename... Is, typename O, typename Op>
 constexpr auto
-transform(Op const op, O o, I f, I const l, Is... fs) {
+transform(Op op, O o, I f, I const l, Is... fs) {
     for (;f != l;++o, (void)++f, ((void)++fs, ...)) {
         *o = op(*f, *fs...);
     }


### PR DESCRIPTION
https://godbolt.org/z/rrnzhdoGn
I just made some test code things appear to still work.

## Using for loop instead of while
For loop can iterate and check the condition in the same line.

## Cast to void
(void), comma operator can be overloaded. So you need to cast to void to force using the built-in comma operator. I'm not sure you can defend against all uses of an overloaded comma operator. I'm not 100% sure when this is needed. So I used it in places where the return value isn't required. Like when you are iterating the iterators. Someone said it's a very uncommon overload and they only saw it used in boost. Though it can happen. std::transform uses the (void) cast.
- https://blog.codeisc.com/2018/01/09/cpp-comma-operator-nice-usages.html
- https://blog.codeisc.com/2017/12/26/cpp-comma-operator-introduction.html
- https://stackoverflow.com/questions/39514765/the-void-the-comma-operator-operator-and-the-impossible-overloading
- https://stackoverflow.com/questions/38357089/why-does-stdtransform-and-similar-cast-the-for-loop-increment-to-void
- https://en.cppreference.com/w/cpp/language/operator_other
- https://www.reddit.com/r/cpp/comments/1tedni/notsocommon_pitfalls_of_c_xpost_rcplusplus/ce7bqnu/
[![C++Now 2017: Jason Turner "(Ab)using C++17"](https://img.youtube.com/vi/AqDsso3S5fg/0.jpg)](https://youtu.be/AqDsso3S5fg?t=276)

## Remove const
Mutable lambdas couldn't be passed to these functions. So we had to remove const
fixes: https://github.com/codereport/An-Algorithm-Library/issues/13

## Forwarding Ref
`any_of` is passing the members directly to the `find` function. I think it's better to forward anything `any_of` doesn't use.
I rewatched this talk for a refresher.
[![CppCon 2019: Klaus Iglberger “Back to Basics: Move Semantics (part 2 of 2)”](https://img.youtube.com/vi/pIzaZbKUw2s/0.jpg)](https://youtu.be/pIzaZbKUw2s)